### PR TITLE
根据运行时异常信息生成响应消息

### DIFF
--- a/src/main/java/com/feiniaojin/gracefulresponse/api/ExceptionAliasFor.java
+++ b/src/main/java/com/feiniaojin/gracefulresponse/api/ExceptionAliasFor.java
@@ -31,6 +31,13 @@ public @interface ExceptionAliasFor {
     String msg() default "Poor network quality!";
 
     /**
+     * 异常渲染器
+     *
+     * @return 异常对应的提示信息
+     */
+    Class<? extends ExceptionRenderer> renderer() default ExceptionRenderer.class;
+
+    /**
      * 作为某个异常的别名
      *
      * @return

--- a/src/main/java/com/feiniaojin/gracefulresponse/api/ExceptionMapper.java
+++ b/src/main/java/com/feiniaojin/gracefulresponse/api/ExceptionMapper.java
@@ -29,4 +29,11 @@ public @interface ExceptionMapper {
      * @return 异常对应的提示信息
      */
     String msg() default "Poor network quality!";
+
+    /**
+     * 异常渲染器
+     *
+     * @return 异常对应的提示信息
+     */
+    Class<? extends ExceptionRenderer> renderer() default ExceptionRenderer.class;
 }

--- a/src/main/java/com/feiniaojin/gracefulresponse/api/ExceptionRenderer.java
+++ b/src/main/java/com/feiniaojin/gracefulresponse/api/ExceptionRenderer.java
@@ -1,0 +1,15 @@
+package com.feiniaojin.gracefulresponse.api;
+
+import com.feiniaojin.gracefulresponse.data.Response;
+
+/**
+ * 异常消息渲染器
+ *
+ * @author cp
+ * @since 2023-02-22 11:09
+ */
+public interface ExceptionRenderer {
+
+    Response render(Throwable clazz, ResponseFactory responseFactory, ResponseStatusFactory responseStatusFactory);
+
+}


### PR DESCRIPTION
支持根据运行时异常信息生成响应消息，如 org.springframework.validation.BindException 的字段校验失败信息 。

ExceptionMapper、ExceptionAliasFor 增加 renderer 属性，用于指定响应信息的生成逻辑。

有此属性时优先调用，否则返回默认的 code、msg。