### PR TITLE
添加spring-boot-configuration-processor(自动生成配置类型)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
             <artifactId>spring-boot-starter-validation</artifactId>
             <version>${spring.boot.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <version>${spring.boot.version}</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <profiles>


### PR DESCRIPTION
添加了spring-boot-configuration-processor依赖，但还有两个属性useValidationMsg和printExceptionInGlobalAdvice尚不知对应的注解，作者可以添加一下然后重新发布，这样用户就可以直接在yml中有提示信息了