### PR TITLE
feat: 跳过指定返回类型

### DIFF
--- a/src/main/java/com/feiniaojin/gracefulresponse/GracefulResponseProperties.java
+++ b/src/main/java/com/feiniaojin/gracefulresponse/GracefulResponseProperties.java
@@ -4,7 +4,6 @@ import com.feiniaojin.gracefulresponse.defaults.DefaultConstants;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
-import java.util.Set;
 
 /**
  * 核心配置类.
@@ -62,6 +61,11 @@ public class GracefulResponseProperties {
      * 例外包路径
      */
     private List<String> excludePackages;
+
+    /**
+     * 例外返回类型
+     */
+    private List<Class> excludeReturnTypes;
 
     /**
      * 不使用@ExceptionMapper和@ExceptionAliasFor修饰的原生异常
@@ -145,6 +149,14 @@ public class GracefulResponseProperties {
 
     public void setExcludePackages(List<String> excludePackages) {
         this.excludePackages = excludePackages;
+    }
+
+    public List<Class> getExcludeReturnTypes() {
+        return excludeReturnTypes;
+    }
+
+    public void setExcludeReturnTypes(List<Class> excludeReturnTypes) {
+        this.excludeReturnTypes = excludeReturnTypes;
     }
 
     public Boolean getOriginExceptionUsingDetailMessage() {

--- a/src/main/java/com/feiniaojin/gracefulresponse/advice/NotVoidResponseBodyAdvice.java
+++ b/src/main/java/com/feiniaojin/gracefulresponse/advice/NotVoidResponseBodyAdvice.java
@@ -85,6 +85,13 @@ public class NotVoidResponseBodyAdvice implements ResponseBodyAdvice<Object> {
                 return false;
             }
         }
+
+        List<Class> excludeReturnTypes = properties.getExcludeReturnTypes();
+        if (!CollectionUtils.isEmpty(excludeReturnTypes) && excludeReturnTypes.contains(method.getReturnType())) {
+            logger.debug("Graceful Response:匹配到excludeReturnTypes例外配置，跳过:returnType={},", method.getReturnType());
+            return false;
+        }
+
         logger.debug("Graceful Response:非空返回值，需要进行封装");
         return true;
     }


### PR DESCRIPTION
对于一些历史遗留项目，例如若依类的框架，或者自己已经封装了返回类型的，而且代码中大量存在return Result.success(xxx)之类的，可以使用该配置。

配置文件中添加
```
  # 例外返回类型，返回该类型的方法将被忽略处理
  exclude-return-types:
    - com.example.demo.Result

```